### PR TITLE
Expose TailWindCss' constructors

### DIFF
--- a/src/TailwindCSS.elm
+++ b/src/TailwindCSS.elm
@@ -1,4 +1,4 @@
-module TailwindCSS exposing (tailwind, TailwindCSS)
+module TailwindCSS exposing (tailwind, TailwindCSS(..))
 
 {-| This library define a list of types to describe Tailwind CSS classes.
 Use them as arguments of tailwind function to become Attribute msg with classes.


### PR DESCRIPTION
Hey there!

I exposed the constructors of `TailwindCSS` to the user. Without this, users have no way to build a `List TailwindCSS` (except for the empty list).

A better alternative would be to instead expose a single function for each variant. That way, whenever you want to add a new variant, you won't need to release a new major version.

I don't use TailWind, but as a Elm user, I would really like to know if/how this package differs from alternatives like
- https://github.com/justinrassier/postcss-elm-css-tailwind
- https://github.com/monty5811/postcss-elm-tailwind
- https://package.elm-lang.org/packages/afidegnum/elm-tailwind/latest/

If I recall correctly, these packages do the alternative of what I mentioned.

Have a nice day!